### PR TITLE
 slight fixes for "templatized" arraycopy static methods.

### DIFF
--- a/activemq-cpp/src/main/decaf/lang/System.cpp
+++ b/activemq-cpp/src/main/decaf/lang/System.cpp
@@ -122,17 +122,13 @@ void System::arraycopy(const char* src, std::size_t srcPos, char* dest,
             __FILE__, __LINE__, "Given Source Pointer was null.");
     }
 
-    if (src == NULL) {
+    if (dest == NULL) {
         throw NullPointerException(
-            __FILE__, __LINE__, "Given Source Pointer was null.");
+            __FILE__, __LINE__, "Given Destination Pointer was null.");
     }
 
     // Now we try and copy, could still segfault.
-    if (src != dest) {
-        ::memcpy(dest + destPos, src + srcPos, length);
-    } else {
-        ::memmove(dest + destPos, src + srcPos, length);
-    }
+    ::memmove(dest + destPos, src + srcPos, length);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -144,17 +140,13 @@ void System::arraycopy(const unsigned char* src, std::size_t srcPos,
             __FILE__, __LINE__, "Given Source Pointer was null.");
     }
 
-    if (src == NULL) {
+    if (dest == NULL) {
         throw NullPointerException(
-            __FILE__, __LINE__, "Given Source Pointer was null.");
+            __FILE__, __LINE__, "Given Destination Pointer was null.");
     }
 
     // Now we try and copy, could still segfault.
-    if (src != dest) {
-        ::memcpy(dest + destPos, src + srcPos, length);
-    } else {
-        ::memmove(dest + destPos, src + srcPos, length);
-    }
+    ::memmove(dest + destPos, src + srcPos, length);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -166,17 +158,13 @@ void System::arraycopy(const short* src, std::size_t srcPos,
             __FILE__, __LINE__, "Given Source Pointer was null.");
     }
 
-    if (src == NULL) {
+    if (dest == NULL) {
         throw NullPointerException(
-            __FILE__, __LINE__, "Given Source Pointer was null.");
+            __FILE__, __LINE__, "Given Destination Pointer was null.");
     }
 
     // Now we try and copy, could still segfault.
-    if (src != dest) {
-        ::memcpy(dest + destPos, src + srcPos, length * sizeof(short));
-    } else {
-        ::memmove(dest + destPos, src + srcPos, length * sizeof(short));
-    }
+    ::memmove(dest + destPos, src + srcPos, length * sizeof(short));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -188,17 +176,13 @@ void System::arraycopy(const int* src, std::size_t srcPos,
             __FILE__, __LINE__, "Given Source Pointer was null.");
     }
 
-    if (src == NULL) {
+    if (dest == NULL) {
         throw NullPointerException(
-            __FILE__, __LINE__, "Given Source Pointer was null.");
+            __FILE__, __LINE__, "Given Destination Pointer was null.");
     }
 
     // Now we try and copy, could still segfault.
-    if (src != dest) {
-        ::memcpy(dest + destPos, src + srcPos, length * sizeof(int));
-    } else {
-        ::memmove(dest + destPos, src + srcPos, length * sizeof(int));
-    }
+    ::memmove(dest + destPos, src + srcPos, length * sizeof(int));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -210,17 +194,13 @@ void System::arraycopy(const long long* src, std::size_t srcPos,
             __FILE__, __LINE__, "Given Source Pointer was null.");
     }
 
-    if (src == NULL) {
+    if (dest == NULL) {
         throw NullPointerException(
-            __FILE__, __LINE__, "Given Source Pointer was null.");
+            __FILE__, __LINE__, "Given Destination Pointer was null.");
     }
 
     // Now we try and copy, could still segfault.
-    if (src != dest) {
-        ::memcpy(dest + destPos, src + srcPos, length * sizeof(long long));
-    } else {
-        ::memmove(dest + destPos, src + srcPos, length * sizeof(long long));
-    }
+    ::memmove(dest + destPos, src + srcPos, length * sizeof(long long));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -232,17 +212,13 @@ void System::arraycopy(const float* src, std::size_t srcPos,
             __FILE__, __LINE__, "Given Source Pointer was null.");
     }
 
-    if (src == NULL) {
+    if (dest == NULL) {
         throw NullPointerException(
-            __FILE__, __LINE__, "Given Source Pointer was null.");
+            __FILE__, __LINE__, "Given Destination Pointer was null.");
     }
 
     // Now we try and copy, could still segfault.
-    if (src != dest) {
-        ::memcpy(dest + destPos, src + srcPos, length * sizeof(float));
-    } else {
-        ::memmove(dest + destPos, src + srcPos, length * sizeof(float));
-    }
+    ::memmove(dest + destPos, src + srcPos, length * sizeof(float));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -254,17 +230,13 @@ void System::arraycopy(const double* src, std::size_t srcPos,
             __FILE__, __LINE__, "Given Source Pointer was null." );
     }
 
-    if( src == NULL ) {
+    if( dest == NULL ) {
         throw NullPointerException(
-            __FILE__, __LINE__, "Given Source Pointer was null." );
+            __FILE__, __LINE__, "Given Destination Pointer was null." );
     }
 
     // Now we try and copy, could still segfault.
-    if( src != dest ) {
-        ::memcpy( dest + destPos, src + srcPos, length * sizeof( double ) );
-    } else {
-        ::memmove( dest + destPos, src + srcPos, length * sizeof( double ) );
-    }
+    ::memmove( dest + destPos, src + srcPos, length * sizeof( double ) );
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- source pointers were tested twice.
- source and destination can still possibly overlap dest = src + 1 for example,
thus might be safer to just use memmove regardless of the situation.