### PR TITLE
Move timer objects to the end of member list

### DIFF
--- a/activemq-cpp/src/main/activemq/transport/inactivity/InactivityMonitor.cpp
+++ b/activemq-cpp/src/main/activemq/transport/inactivity/InactivityMonitor.cpp
@@ -72,9 +72,6 @@ namespace inactivity {
         Pointer<ReadChecker> readCheckerTask;
         Pointer<WriteChecker> writeCheckerTask;
 
-        Timer readCheckTimer;
-        Timer writeCheckTimer;
-
         Pointer<CompositeTaskRunner> asyncTasks;
 
         Pointer<AsyncSignalReadErrorkTask> asyncReadTask;
@@ -97,6 +94,9 @@ namespace inactivity {
         long long initialDelayTime;
 
         bool keepAliveResponseRequired;
+
+        Timer readCheckTimer;
+        Timer writeCheckTimer;
 
         InactivityMonitorData(const Pointer<WireFormat> wireFormat) :
             wireFormat(wireFormat),


### PR DESCRIPTION
In high CPU load it can happen, that Timer thread wakes up,
is swapped out, and when application resumes it does not resume with timer
thread, but transport thread, that decides to do failover, destroys
`InactivityMonitor` object. When its members are getting destroyed,
they arrive at `Timer` object that joins, timer thread resumes in
`writeCheck` or `readCheck` method, only to find out `asyncTasks` is already
destroyed because it comes later in member declaration list so it was
destroyed first. Moving `Timer` object to the end of the list, guarantees
that they will be destroyed first, so their threads will get joined and
allowed to finish, before the rest of the object is destroyed.

Closes AMQCPP-626