### PR TITLE
Fix Visual Studio 2017 Build

### DIFF
--- a/activemq-cpp/src/main/decaf/internal/security/windows/SecureRandomImpl.cpp
+++ b/activemq-cpp/src/main/decaf/internal/security/windows/SecureRandomImpl.cpp
@@ -23,6 +23,8 @@
 #include <decaf/lang/exceptions/IllegalArgumentException.h>
 #include <decaf/util/Random.h>
 
+#include <memory>
+
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0500
 


### PR DESCRIPTION
Added `#include <memory>` for `std::auto_ptr` to fix building on Visual Studio 2017 (probably for 2019 also, but I don't have it installed, so I can't check).